### PR TITLE
Resolve actions/cache misses

### DIFF
--- a/.github/workflows/cache-dependencies.yml
+++ b/.github/workflows/cache-dependencies.yml
@@ -1,0 +1,34 @@
+name: Populate Dependency Cache
+
+# Reference: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#example-of-search-priority
+# actions/cache is branch scoped by default. Since the merge queue runs on a staging branch that then 
+# gets deleted after tests run, there was never cache hits between CI runs. 
+# actions/cache does check the default branch cache if there's a cache miss on the staging branch.
+# Populate the cache on merges to main so that it can then be used on pull request and merge queue
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  dependency-cache:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache Bazel
+        id: cache-bazel
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/bazel
+          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'MODULE.bazel.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bazel-
+
+      # only repopulate the cache on a cache miss. this occurs when some dependency changes
+      - if: ${{ steps.cache-bazel.outputs.cache-hit != 'true' }}
+        run: ./bazelw build //...

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel') }}
+          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'MODULE.bazel.lock') }}
           restore-keys: |
             ${{ runner.os }}-bazel-
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel') }}
+          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'MODULE.bazel.lock') }}
           restore-keys: |
             ${{ runner.os }}-bazel-
       


### PR DESCRIPTION
actions/cache is branch scoped by default. Since the merge queue runs on a staging branch that then gets deleted after tests run, there was never cache hits between CI runs. actions/cache does check the default branch cache if there's a cache miss on the staging branch. Populate the cache on merges to main so that it can then be used on pull request and merge queue