### PR TITLE
Fixed clang-format failing

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,7 @@ AlignAfterOpenBracket: BlockIndent
 TabWidth: 4
 IndentWidth: 4
 ColumnLimit: 0
-InsertFinalNewline: true
 AllowShortFunctionsOnASingleLine: Empty
+InsertNewlineAtEOF: True
 WhitespaceSensitiveMacros:
   - CN

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,7 +33,7 @@ git_override(
 # clangd hardcodes where to search for the headers relative to itself.
 # To fix, you need to tell vscode's clangd extension to use the
 # clangd from the toolchain and not the system. Should be hereish:
-# $(pwd)/external/+_repo_rules2+clang-linux-x86_64/bin/clangd
+# echo $(pwd)/external/+_repo_rules2+clang-linux-x86_64/bin/clangd
 bazel_dep(name = "hedron_compile_commands", version = "0.0.0", dev_dependency = True)
 git_override(
     module_name = "hedron_compile_commands",


### PR DESCRIPTION
the .clang-format file had a setting not recognized by clang-format. New .clang-format works with the hermetic clangd